### PR TITLE
feat: sanitize dynamic HTML rendering

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -412,10 +412,10 @@ class ChatbotSidebar {
         
         const timeStr = this.formatTime(new Date());
         
-        // Format bot messages with markdown support
-        const formattedContent = (!isError && type === 'bot') ? 
-            this.formatBotMessage(content) : content;
-        
+        // Sanitize and format content
+        const formattedContent = (!isError && type === 'bot') ?
+            this.formatBotMessage(content) : DOMUtils.escapeHTML(content);
+
         messageDiv.innerHTML = `
             ${formattedContent}
             <div class="ai-chatbot-message-time">${timeStr}</div>
@@ -439,7 +439,9 @@ class ChatbotSidebar {
             return content;
         }
 
-        return content
+        const safeContent = DOMUtils.escapeHTML(content);
+
+        return safeContent
             // Handle numbered lists (1. 2. 3.)
             .replace(/^(\d+)\.\s+(.+)$/gm, '<div class="list-item numbered"><span class="list-number">$1.</span> $2</div>')
             // Handle bullet points (- or *)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -261,6 +261,17 @@ class Formatter {
  * DOM manipulation utilities
  */
 class DOMUtils {
+    static escapeHTML(str) {
+        if (typeof str !== 'string') return '';
+        return str.replace(/[&<>"']/g, char => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#039;'
+        })[char]);
+    }
+
     static createElement(tag, className = '', attributes = {}) {
         const element = document.createElement(tag);
         

--- a/options/options.js
+++ b/options/options.js
@@ -632,12 +632,19 @@ class OptionsPage {
         this.connectionDot.className = `status-dot ${connected ? 'connected' : 'disconnected'}`;
         this.connectionText.textContent = connected ? 'Connected' : 'Disconnected';
         
+        // Clear previous result
+        this.connectionResult.textContent = '';
+
         if (connected) {
-            this.connectionResult.innerHTML = '<div class="success-message">✅ Connection successful</div>';
+            const successDiv = document.createElement('div');
+            successDiv.className = 'success-message';
+            successDiv.textContent = '✅ Connection successful';
+            this.connectionResult.appendChild(successDiv);
         } else if (error) {
-            this.connectionResult.innerHTML = `<div class="error-message">❌ ${error}</div>`;
-        } else {
-            this.connectionResult.innerHTML = '';
+            const errorDiv = document.createElement('div');
+            errorDiv.className = 'error-message';
+            errorDiv.textContent = `❌ ${error}`;
+            this.connectionResult.appendChild(errorDiv);
         }
     }
 
@@ -950,12 +957,23 @@ class OptionsPage {
             warning: '⚠️'
         }[type] || 'ℹ️';
         
-        toast.innerHTML = `
-            <span class="toast-icon">${icon}</span>
-            <span class="toast-message">${message}</span>
-            <button class="toast-close" onclick="this.parentElement.remove()">×</button>
-        `;
-        
+        const iconSpan = document.createElement('span');
+        iconSpan.className = 'toast-icon';
+        iconSpan.textContent = icon;
+
+        const messageSpan = document.createElement('span');
+        messageSpan.className = 'toast-message';
+        messageSpan.textContent = message;
+
+        const closeBtn = document.createElement('button');
+        closeBtn.className = 'toast-close';
+        closeBtn.textContent = '×';
+        closeBtn.addEventListener('click', () => toast.remove());
+
+        toast.appendChild(iconSpan);
+        toast.appendChild(messageSpan);
+        toast.appendChild(closeBtn);
+
         container.appendChild(toast);
         
         // Auto remove after 5 seconds

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -172,6 +172,7 @@
         </div>
     </div>
 
+    <script src="../lib/utils.js"></script>
     <script src="popup.js"></script>
 </body>
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -268,7 +268,7 @@ class ChatbotPopup {
         const contentDiv = document.createElement('div');
         contentDiv.className = 'message-content';
         
-        // 마크다운 기본 지원 (링크, 볼드, 이탤릭)
+        // Sanitize and support basic markdown for bot messages
         if (!isError && type === 'bot') {
             contentDiv.innerHTML = this.formatBotMessage(content);
         } else {
@@ -309,7 +309,9 @@ class ChatbotPopup {
             return content;
         }
 
-        return content
+        const safeContent = DOMUtils.escapeHTML(content);
+
+        return safeContent
             // Handle numbered lists (1. 2. 3.)
             .replace(/^(\d+)\.\s+(.+)$/gm, '<div class="list-item numbered"><span class="list-number">$1.</span> $2</div>')
             // Handle bullet points (- or *)


### PR DESCRIPTION
## Summary
- add shared `escapeHTML` utility
- sanitize chat and popup messages before injecting into DOM
- replace `innerHTML` usage in options page to avoid unsafe rendering

## Testing
- `npm test` (fails: fetch failed)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891c16996e4832ca18b7754ee976d58